### PR TITLE
Three small changes

### DIFF
--- a/gantryd.py
+++ b/gantryd.py
@@ -5,6 +5,7 @@ import argparse
 import json
 
 ETCD_HOST = '127.0.0.1'
+ETCD_PORT = 4001
 
 def run(dclient, args):
   """ Runs gantryd. """
@@ -67,13 +68,14 @@ def start():
   parser.add_argument('project', help='The name of the project containing the components')
   parser.add_argument('configfile', help='The name of the config file. Only applies to setconfig.', nargs='?')
   parser.add_argument('-c', help='A component to watch and run', nargs='+', type=str, dest='component')
-  parser.add_argument('-etcd', help='The etcd endpoint to which the client should connect. Defaults to 127.0.0.1:4001', dest='etcd_host', nargs='?', const=ETCD_HOST)
+  parser.add_argument('-etcd', help='The etcd endpoint to which the client should connect. Defaults to 127.0.0.1', dest='etcd_host', nargs='?', const=ETCD_HOST)
+  parser.add_argument('-etcdport', help='The client port of the etcd endpoint. Defaults to 4001.', dest='etcd_port', nargs='?', const=ETCD_PORT)
 
   # Parse the arguments.
   args = parser.parse_args()
 
   # Initialize the gantryd client.
-  dclient = GantryDClient(args.etcd_host or ETCD_HOST, args.project)
+  dclient = GantryDClient(args.etcd_host or ETCD_HOST, args.project, int(args.etcd_port) or ETCD_PORT)
 
   # Run the action.
   action = ACTIONS[args.action]

--- a/gantryd.py
+++ b/gantryd.py
@@ -73,9 +73,12 @@ def start():
 
   # Parse the arguments.
   args = parser.parse_args()
+  port = ETCD_PORT
+  if args.etcd_port:
+    port = int(args.etcd_port)
 
   # Initialize the gantryd client.
-  dclient = GantryDClient(args.etcd_host or ETCD_HOST, args.project, int(args.etcd_port) or ETCD_PORT)
+  dclient = GantryDClient(args.etcd_host or ETCD_HOST, args.project, port)
 
   # Run the action.
   action = ACTIONS[args.action]

--- a/gantryd.py
+++ b/gantryd.py
@@ -73,9 +73,7 @@ def start():
 
   # Parse the arguments.
   args = parser.parse_args()
-  port = ETCD_PORT
-  if args.etcd_port:
-    port = int(args.etcd_port)
+  port = int(args.etcd_port) if args.etcd_port else ETCD_PORT
 
   # Initialize the gantryd client.
   dclient = GantryDClient(args.etcd_host or ETCD_HOST, args.project, port)

--- a/gantryd/client.py
+++ b/gantryd/client.py
@@ -22,7 +22,7 @@ REPORT_TTL = 60 # Report that this machine is running, every 60 seconds
 
 class GantryDClient(object):
   """ A client in gantryd. """
-  def __init__(self, etcdHost, projectName):
+  def __init__(self, etcdHost, projectName, etcdPort):
     self.project_name = projectName
     self.runtime_manager = None
     self.components = []
@@ -35,7 +35,7 @@ class GantryDClient(object):
     self.logger = logging.getLogger(__name__)
 
     # Initialize the etcd client that we'll use.
-    self.etcd_client = etcd.Client(host=etcdHost)
+    self.etcd_client = etcd.Client(host=etcdHost, port=etcdPort)
 
     # Initialize the thread used for reporting the status of this machine to etcd.
     self.reporting_thread = threading.Thread(target=self.reportMachineStatus, args=[])

--- a/gantryd/componentstate.py
+++ b/gantryd/componentstate.py
@@ -5,6 +5,7 @@ from etcdpaths import getComponentStatePath
 READY_STATUS = 'ready'
 STOPPED_STATUS = 'stopped'
 KILLED_STATUS = 'killed'
+PULL_FAIL = 'pullfail'
 
 IMAGE_ID = 'imageid'
 

--- a/gantryd/componentwatcher.py
+++ b/gantryd/componentwatcher.py
@@ -3,7 +3,7 @@ import threading
 import json
 import logging
 
-from gantryd.componentstate import ComponentState, STOPPED_STATUS, KILLED_STATUS, READY_STATUS
+from gantryd.componentstate import ComponentState, STOPPED_STATUS, KILLED_STATUS, READY_STATUS, PULL_FAIL
 from util import report, fail, getDockerClient, ReportLevels
 
 CHECK_SLEEP_TIME = 30 # 30 seconds
@@ -74,7 +74,7 @@ class ComponentWatcher(object):
           # Ensure that the component is still ready.
           state = self.state.getState()
           current_status = ComponentState.getStatusOf(state)
-          if current_status == READY_STATUS:
+          if current_status == READY_STATUS or current_status == PULL_FAIL:
             report('Component ' + self.component.getName() + ' is not healthy. Restarting...',
                    project=self.project_name, component=self.component)
 

--- a/gantryd/componentwatcher.py
+++ b/gantryd/componentwatcher.py
@@ -74,7 +74,7 @@ class ComponentWatcher(object):
           # Ensure that the component is still ready.
           state = self.state.getState()
           current_status = ComponentState.getStatusOf(state)
-          if current_status == READY_STATUS or current_status == PULL_FAIL:
+          if current_status == READY_STATUS:
             report('Component ' + self.component.getName() + ' is not healthy. Restarting...',
                    project=self.project_name, component=self.component)
 
@@ -118,7 +118,7 @@ class ComponentWatcher(object):
       return self.handleStopped(was_initial_check)
     elif current_status == KILLED_STATUS:
       return self.handleKilled(was_initial_check)
-    elif current_status == READY_STATUS:
+    elif current_status == READY_STATUS or current_status = PULL_FAIL:
       with self.update_lock:
         return self.handleReady(state, was_initial_check)
 

--- a/gantryd/componentwatcher.py
+++ b/gantryd/componentwatcher.py
@@ -118,7 +118,7 @@ class ComponentWatcher(object):
       return self.handleStopped(was_initial_check)
     elif current_status == KILLED_STATUS:
       return self.handleKilled(was_initial_check)
-    elif current_status == READY_STATUS or current_status = PULL_FAIL:
+    elif current_status == READY_STATUS or current_status == PULL_FAIL:
       with self.update_lock:
         return self.handleReady(state, was_initial_check)
 

--- a/runtime/component.py
+++ b/runtime/component.py
@@ -340,6 +340,7 @@ class Component(object):
       for image in images:
         if 'RepoTags' in image.keys() and self.config.getFullImage() in image['RepoTags']:
           return
+
     try:
       client.pull(self.config.repo, tag=self.config.tag)
     except Exception as e:

--- a/runtime/component.py
+++ b/runtime/component.py
@@ -336,12 +336,10 @@ class Component(object):
         we attempt to pull the image.
     """
     images = client.images(name=self.config.repo)
-    if images and len(images) > 0:
+    if images:
       for image in images:
-        if 'RepoTags' in image.keys():
-          for repotag in image['RepoTags']:
-            if repotag == self.config.getFullImage():
-              return
+        if 'RepoTags' in image.keys() and self.config.getFullImage() in image['RepoTags']:
+          return
     try:
       client.pull(self.config.repo, tag=self.config.tag)
     except Exception as e:

--- a/runtime/component.py
+++ b/runtime/component.py
@@ -335,9 +335,14 @@ class Component(object):
     """ Ensures that the image for this component is present locally. If not,
         we attempt to pull the image.
     """
-    images = client.images(name=self.config.getFullImage())
-    if not images or not len(images) > 0:
-      try:
-        client.pull(self.config.repo)
-      except Exception as e:
-        fail('Could not pull repo ' + self.config.repo, component=self, exception=str(e))
+    images = client.images(name=self.config.repo)
+    if images and len(images) > 0:
+      for image in images:
+        if 'RepoTags' in image.keys():
+          for repotag in image['RepoTags']:
+            if repotag == self.config.getFullImage():
+              return
+    try:
+      client.pull(self.config.repo, tag=self.config.tag)
+    except Exception as e:
+      fail('Could not pull repo ' + self.config.repo, component=self, exception=str(e))


### PR DESCRIPTION
1) ensureimage was checking if the docker image existed by querying the docker service for the repository and tag (ex: my/repo:tag). The result of this check will always be empty because docker only checks the repository field. I get the list of images with a matching repository and iterate through the results to see if their tag matches the component. I also changed the pull in ensureimage to include the tag as it fails without it.

2) The etcd port wasn't settable. The etcd library has separate parameters for host and port. It always attaches its port parameter onto whatever host is passed to it. As gantryd doesn't pass a port, the port was always being set to 4001 (or worse, if your host parameter was a uri with a port at the end, you'd try to connect on http://yourhost:yourport:4001). This makes it impossible for gantryd to connect to a cluster on the recommended etcd2 port of 2379. I added a command line argument to get a port to pass to the etcd client. I left the default at 4001.

3) If a pull from a docker repository fails, the machine gets a status of 'pullfail' which is unhandled. The machine never leaves this status and thus never attempts to pull the repo again until gantryd is stopped and the status expires. I made 'pullfail' run the ready state code so that the pull is reattempted.