### PR TITLE
Infer docker client api version automatically from server

### DIFF
--- a/util.py
+++ b/util.py
@@ -11,7 +11,7 @@ def enum(*sequential, **named):
 
 ReportLevels = enum(BACKGROUND=-2, EXTRA=-1, NORMAL=0, IMPORTANT=1)
 
-client = docker.Client()
+client = docker.Client(version='auto')
 
 def pickUnusedPort():
   s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)


### PR DESCRIPTION
The docker client was being instantiated with no version argument, thus defaulting to the value held in `DEFAULT_DOCKER_API_VERSION` from docker-py.  The current api version (1.19) is not backwards compatible, which means gantry will not work on machines running docker engine < 1.7.  Passing `version='auto'` when creating the client will infer / respect the api version of the local docker daemon.