### PR TITLE
pin psutil version to >=2.2.1,<3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 termcolor
 docker-py
-psutil
+psutil >=2.2.1,<3.0
 jinja2
 python-etcd
 peewee


### PR DESCRIPTION
There is a backwards incompatibility issue with psutil >=3.0, which is what pip installs by default.  While this is probably just a stop-gap measure, pinning the version as such avoids the following failure case:

```sh
root@3f9f6155ac7b:/opt/gantryd# pip list | grep psutil # 3.* fails
psutil (3.2.1)

root@3f9f6155ac7b:/opt/gantryd# ./gantry.py /etc/gantry/gantry.conf update test
[test] Starting container f09d2fcbf913
[test] Waiting for health checks...
[test] Running health check: http
Checking HTTP address in container f09d2fcbf913: http://10.1.1.165:3333
No handlers could be found for logger "health.healthcheck"
[test] Health check failed
[test] Sleeping 3 second(s)...
[test] Running health check: http
Checking HTTP address in container f09d2fcbf913: http://10.1.1.165:3333
[test] Redirecting traffic to new container
Finding running containers...
Updating proxy...
[test] Terminating container: 8af203b1f02c
10/09/2015 04:08PM | Monitor check started
[test] Sending 0 termination signals
[test] Waiting for 1 termination checks
[test] Running termination check: connection
Traceback (most recent call last):
  File "./gantry.py", line 105, in <module>
    run()
  File "./gantry.py", line 102, in run
    cleanup_monitor(None, None)
  File "./gantry.py", line 96, in cleanup_monitor
    manager.join()
  File "/opt/gantryd/runtime/manager.py", line 225, in join
    self.monitor_futures.get().get()
  File "/usr/lib/python2.7/multiprocessing/pool.py", line 558, in get
    raise self._value
AttributeError: 'Process' object has no attribute 'get_connections'
```
```sh
root@3f9f6155ac7b:/opt/gantryd# pip uninstall -q psutil
root@3f9f6155ac7b:/opt/gantryd# pip install -q "psutil>=2.2.1,<3.0" # downgraded
Proceed (y/n)? y

root@3f9f6155ac7b:/opt/gantryd# ./gantry.py /etc/gantry/gantry.conf update test
[test] Starting container 44804fefacfa
[test] Waiting for health checks...
[test] Running health check: http
Checking HTTP address in container 44804fefacfa: http://10.1.1.166:3333
No handlers could be found for logger "health.healthcheck"
[test] Health check failed
[test] Sleeping 3 second(s)...
[test] Running health check: http
Checking HTTP address in container 44804fefacfa: http://10.1.1.166:3333
[test] Redirecting traffic to new container
Finding running containers...
Updating proxy...
[test] Terminating container: f09d2fcbf913
10/09/2015 04:15PM | Monitor check started
[test] Sending 0 termination signals
[test] Waiting for 1 termination checks
[test] Running termination check: connection
Container has no remaining connections: f09d2fcbf913
10/09/2015 04:15PM | Monitor check finished
10/09/2015 04:15PM | Shutting down container: f09d2fcbf913
```