### PR TITLE
add volumes_from config item

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ The configuration defines the various components of the project you want to mana
        "healthChecks": [
          { "kind": "http", "port": 8888, "path": "/some/path" }
        ],
+       "volumesFrom": [
+         "somedatacontainer"
+       ],
        "bindings": [
          { "external": "/an/external/path", "volume": "/some/container/path"}
        ],
@@ -97,6 +100,7 @@ The configuration defines the various components of the project you want to mana
 | healthChecks          | The various checks to run to ensure the container is healthy (see below for list) |             |
 | terminationSignals    | Signals which should be sent to a specific container when it should be shut down  |             |
 | terminationChecks     | The various checks to run to ensure that the container is ready to be shut down   | connections |
+| volumesFrom           | Container(s), by name, whose volume(s) should be mounted into the container       |             |
 | bindings              | Mapping between external hosts paths and the corresponding container volumes      |             |
 | defineComponentLinks  | Defines the component links exported by this component                            |             |
 | requireComponentLinks | Defines the component links imported/required by this component                   |             |

--- a/config/GantryConfig.py
+++ b/config/GantryConfig.py
@@ -106,6 +106,7 @@ class _Component(CFObject):
   user = CFField('user').default('')
   ports = CFField('ports').list_of(_PortMapping).default([])
   bindings = CFField('bindings').list_of(_VolumeBinding).default([])
+  volumes_from = CFField('volumesFrom').list_of(str).default([])
   ready_checks = CFField('readyChecks').list_of(_HealthCheck).default([])
   health_checks = CFField('healthChecks').list_of(_HealthCheck).default([])
   ready_timeout = CFField('readyTimeout').kind(int).default(10000)

--- a/runtime/component.py
+++ b/runtime/component.py
@@ -224,6 +224,7 @@ class Component(object):
       report('Container will be run in privileged mode', component=self)
 
     client.start(container, binds=self.config.getBindings(container['Id']),
+                 volumes_from=self.config.volumes_from,
                  privileged=self.config.privileged)
 
     # Health check until the instance is ready.


### PR DESCRIPTION
Added support for a `volumesFrom` configuration item, which is simply passed through to docker-py and the docker API.