### PR TITLE
ensure that if a container name is provided we don't loosely use repo…

### DIFF
--- a/runtime/component.py
+++ b/runtime/component.py
@@ -255,8 +255,9 @@ class Component(object):
     """ Returns all the matching containers for this component. """
     containers = []
     for container in client.containers():
-      if (container['Image'] == self.config.getFullImage() or
-          getContainerComponent(container) == self.getName()):
+      containerName = getContainerComponent(container)
+      if ((not containerName and container['Image'] == self.config.getFullImage()) or
+          containerName == self.getName()):
         containers.append(container)
 
     return containers


### PR DESCRIPTION
…:tag for container comparisons

The current functionality prevents multiple components from running in gantryd using the same `repo:tag`. This change ensures that there is not a containerName before assuming the image matching means they're the same component.