### PR TITLE
Add docker tcp support

### DIFF
--- a/gantryd.py
+++ b/gantryd.py
@@ -70,10 +70,15 @@ def start():
   parser.add_argument('-c', help='A component to watch and run', nargs='+', type=str, dest='component')
   parser.add_argument('-etcd', help='The etcd endpoint to which the client should connect. Defaults to 127.0.0.1', dest='etcd_host', nargs='?', const=ETCD_HOST)
   parser.add_argument('-etcdport', help='The client port of the etcd endpoint. Defaults to 4001.', dest='etcd_port', nargs='?', const=ETCD_PORT)
+  parser.add_argument('-H', '--host', dest='docker_url', default='unix://var/run/docker.sock', help='Set url for docker host, defaults to unix://var/run/docker.sock')
 
   # Parse the arguments.
   args = parser.parse_args()
   port = int(args.etcd_port) if args.etcd_port else ETCD_PORT
+  docker_url = args.docker_url
+
+  # Connect to docker
+  connectDockerClient(docker_url)
 
   # Initialize the gantryd client.
   dclient = GantryDClient(args.etcd_host or ETCD_HOST, args.project, port)

--- a/util.py
+++ b/util.py
@@ -11,7 +11,11 @@ def enum(*sequential, **named):
 
 ReportLevels = enum(BACKGROUND=-2, EXTRA=-1, NORMAL=0, IMPORTANT=1)
 
-client = docker.Client(version='auto')
+client = None
+
+def connectDockerClient(docker_url):
+  global client
+  client = docker.Client(base_url=docker_url, version='auto')
 
 def pickUnusedPort():
   s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -47,4 +51,6 @@ def fail(reason, project=None, component=None, exception=None):
 
 def getDockerClient():
   """ Returns the docker client. """
+  if client is None:
+      connectDockerClient('unix://var/run/docker.sock')
   return client


### PR DESCRIPTION
This add the ability to specify the docker url, in order to support tcp connections. This is useful when combining gantry with docker swarm.